### PR TITLE
feat: add ai-kit.manifest.json + project-tooling.json support

### DIFF
--- a/.specify/ai-kit.manifest.json
+++ b/.specify/ai-kit.manifest.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "1.0",
+  "integration": "copilot",
+  "version": "1.0.0",
+  "links": [
+    {
+      "source": ".github/agents",
+      "target": ".github/agents",
+      "mode": "link_children",
+      "skip_patterns_unless_paths_exist": [
+        {
+          "patterns": [
+            "speckit.*"
+          ],
+          "paths": [
+            ".speckit"
+          ]
+        }
+      ]
+    },
+    {
+      "source": ".github/prompts",
+      "target": ".github/prompts",
+      "mode": "link_dir"
+    },
+    {
+      "source": ".github/skills",
+      "target": ".github/skills",
+      "mode": "link_dir"
+    },
+    {
+      "source": ".github/hooks",
+      "target": ".github/hooks",
+      "mode": "link_dir"
+    }
+  ],
+  "copies": [
+    {
+      "source": ".github/copilot-instructions.md",
+      "target": ".github/copilot-instructions.md",
+      "if_missing": true
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Used as a git submodule (at `.copilot/`) to provide:
 
 > **Note:** `speckit.*` agents reference `.specify/templates/` which is provided by `speckit-core`.
 > When used without `speckit-core`, those agents are automatically skipped at bootstrap time.
+>
+> When paired with `speckit-core`, this repo now exposes `.specify/ai-kit.manifest.json` so the generic
+> linker in `speckit-core` can attach Copilot-owned files without hardcoding `.github/*` logic in every consumer.
 
 ## Usage
 
@@ -32,6 +35,14 @@ Set `copilot_enabled: true` in your `repos.json` entry — the bootstrap workflo
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/jwill824/copilot-kit/main/install.sh)
 ```
+
+If `.speckit/` is already present, the installer delegates to:
+
+```bash
+bash .speckit/.specify/scripts/bash/link-ai-integration.sh copilot .copilot
+```
+
+If `speckit-core` is not present, `copilot-kit` falls back to its standalone linking behavior.
 
 ## Spec-Kit Workflow
 

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,38 @@ success() { echo -e "  ${GREEN}✓${RESET}  $*"; }
 warn()    { echo -e "  ${YELLOW}⚠${RESET}  $*"; }
 error()   { echo -e "  ${RED}✗${RESET}  $*" >&2; exit 1; }
 
+write_project_tooling() {
+  local path=".specify/project-tooling.json"
+  local tmp
+  tmp="$(mktemp)"
+
+  mkdir -p .specify
+
+  if [ -f "$path" ]; then
+    # Merge: preserve spec_workflow and other keys, update ai_tool + ai_kit_path
+    python3 - "$path" "$tmp" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+data.setdefault("spec_workflow", True)
+data["ai_tool"] = "copilot"
+data["ai_kit_path"] = ".copilot"
+json.dump(data, open(sys.argv[2], "w"), indent=2)
+open(sys.argv[2], "a").write("\n")
+PY
+    mv "$tmp" "$path"
+    success "Updated $path"
+  else
+    cat > "$path" <<'JSON'
+{
+  "spec_workflow": true,
+  "ai_tool": "copilot",
+  "ai_kit_path": ".copilot"
+}
+JSON
+    success "Created $path"
+  fi
+}
+
 echo -e "\n${BOLD}🔧 copilot-kit installer${RESET}\n"
 
 cd "$TARGET_DIR" || error "Cannot cd to $TARGET_DIR"
@@ -36,6 +68,18 @@ else
   git submodule update --init "$SUBMODULE_PATH"
 fi
 success "Submodule ready at .copilot/\n"
+
+if [ -x ".speckit/.specify/scripts/bash/link-ai-integration.sh" ] && [ -f ".copilot/.specify/ai-kit.manifest.json" ]; then
+  echo -e "${BOLD}Step 2: Generic integration linking${RESET}"
+  bash ".speckit/.specify/scripts/bash/link-ai-integration.sh" copilot .copilot
+  # linker writes project-tooling.json automatically
+  echo ""
+
+  echo -e "${BOLD}${GREEN}✅  copilot-kit installed!${RESET}\n"
+  echo -e "  ${BOLD}Next:${RESET} customize ${CYAN}.github/copilot-instructions.md${RESET} for your project"
+  echo -e "  ${BOLD}Update later:${RESET} ${CYAN}git submodule update --remote .copilot${RESET}\n"
+  exit 0
+fi
 
 # ── 2. Agent symlinks (individual files) ──────────────────────────────────────
 echo -e "${BOLD}Step 2: Agent symlinks${RESET}"
@@ -115,6 +159,11 @@ See `.specify/memory/stack.md` for tooling and commands.
 STUB
   success "Created .github/copilot-instructions.md"
 fi
+echo ""
+
+# ── Standalone: write project-tooling.json ────────────────────────────────────
+echo -e "${BOLD}Step 5: Project tooling declaration${RESET}"
+write_project_tooling
 echo ""
 
 echo -e "${BOLD}${GREEN}✅  copilot-kit installed!${RESET}\n"


### PR DESCRIPTION
## Summary

Adds the AI kit linking manifest and project-tooling.json integration to copilot-kit.

### Changes

**`.specify/ai-kit.manifest.json`** (new) — Kit contract declaring owned paths and linking modes:
- `link_children` for `.github/agents` — symlinks individual agent files; skips `speckit.*` agents when `.speckit` is absent in the consumer repo
- `link_dir` for `.github/prompts`, `.github/skills`, `.github/hooks`
- `if_missing` copy for `.github/copilot-instructions.md`

**`install.sh`** — Two-mode behavior:
- **Generic linker path** (when `.speckit` is present): delegates to `link-ai-integration.sh`, which writes `project-tooling.json` automatically
- **Standalone path** (no `.speckit`): adds Step 5 to write/merge `project-tooling.json` with `ai_tool: "copilot"`, `ai_kit_path: ".copilot"`, preserving any existing `spec_workflow` value

**`README.md`** — Documents two-mode behavior and `ai-kit.manifest.json` contract

### Two modes

| Mode | Condition | Behavior |
|------|-----------|----------|
| Copilot + speckit | `.speckit` present + `ai-kit.manifest.json` | Generic linker runs; all assets including `speckit.*` agents linked |
| Copilot-only | No `.speckit` | Standalone linking; `speckit.*` agents skipped |

### Related PRs
- speckit-core: jwill824/speckit-core#3